### PR TITLE
Supporting paging from MDC Socrata

### DIFF
--- a/Src/OpenPermit.SQL/OpenPermit.SQL.csproj
+++ b/Src/OpenPermit.SQL/OpenPermit.SQL.csproj
@@ -77,6 +77,11 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="SQLScripts\Inspections.sql" />
+    <Content Include="SQLScripts\Permit.sql" />
+    <Content Include="SQLScripts\PermitStatus.sql" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
The default page size is 1000. Currently only getting 1000 records on sync job. This patch will enable us to get all.